### PR TITLE
Fix windows not receiving arrow keys (golang/go#68830)

### DIFF
--- a/term_windows.go
+++ b/term_windows.go
@@ -26,6 +26,7 @@ func makeRaw(fd int) (*State, error) {
 		return nil, err
 	}
 	raw := st &^ (windows.ENABLE_ECHO_INPUT | windows.ENABLE_PROCESSED_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_OUTPUT)
+	raw |= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
 	if err := windows.SetConsoleMode(windows.Handle(fd), raw); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix here pending PRs merging

Shamelessly borrowed from https://github.com/containerd/console/blob/v1.0.4/console_windows.go#L194